### PR TITLE
Linux: update for 2025.01.16 release

### DIFF
--- a/linux/net.hhoney.tinycrate.metainfo.xml
+++ b/linux/net.hhoney.tinycrate.metainfo.xml
@@ -55,11 +55,16 @@
     </screenshot>
     <screenshot>
       <image>https://raw.githubusercontent.com/HarmonyHoney/tiny_crate/10312ba618be82d6bb9de63a087a3a3183cda5d2/media/image/screens/5.png</image>
-      <caption>Eighteen levels to master</caption>
+      <caption>Five worlds and over 30 levels to master</caption>
     </screenshot>
   </screenshots>
 
   <releases>
+    <release version="2025.01.16" date="2025-01-16">
+      <description>
+        <p>Updated icon and under-the-hood cleanup</p>
+      </description>
+    </release>
     <release version="2024.09.18" date="2024-09-18">
       <description>
         <p>Patch 13 - Touch Controls Ghosting Fixed</p>

--- a/linux/net.hhoney.tinycrate.yml
+++ b/linux/net.hhoney.tinycrate.yml
@@ -19,8 +19,8 @@ modules:
     path: ../
 
   - type: file
-    url: https://github.com/HarmonyHoney/tiny_crate/releases/download/2024.12.16/Tiny-Crate.pck
-    sha256: 538cd6dded643b93011fbd6681da2dbe5f5d01c8d56625d4c1cc77dce174fd29
+    url: https://github.com/HarmonyHoney/tiny_crate/releases/download/2025.1.16/Tiny-Crate.pck
+    sha256: ccf01fa100fe876e2a5d222f4cc7e60f57d2e09728f9948a188fa9ea4540d01b
 
   build-commands:
   - install -Dm644 Tiny-Crate.pck ${FLATPAK_DEST}/bin/godot-runner.pck


### PR DESCRIPTION
Required to get the updated release notes onto Flathub/Linux app stores. I also corrected the last screenshot caption; I said 18 levels for some reason when it's five worlds and over 30 levels.