### PR TITLE
Workflows: improve filenames of CI artifacts

### DIFF
--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   GODOT_VERSION: 3.6
-  EXPORT_NAME: tinycrate-linux
+  EXPORT_NAME: tinycrate-ci
 
 jobs:
   export:
@@ -53,4 +53,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh release upload '${{ github.ref_name }}' ${{ env.EXPORT_NAME }}.pck --repo '${{ github.repository }}'
+          mv '${{ env.EXPORT_NAME }}.pck' '${{ env.EXPORT_NAME }}-${{ github.ref_name }}.pck'
+          gh release upload '${{ github.ref_name }}' '${{ env.EXPORT_NAME }}-${{ github.ref_name }}.pck'  --repo '${{ github.repository }}'


### PR DESCRIPTION
- Changes the export name to `tinycrate-ci` to make it clear the artifacts are generated in CI
- Appends the release tag to artifacts for releases resulting in e.g. `tinycrate-ci-2025.03.05.pck`

Fixes #12