### PR TITLE
linux: update Flatpak manifest to use 25.08 runtime

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -13,11 +13,11 @@ jobs:
   flatpak:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08
       options: --privileged
     steps:
-    - uses: actions/checkout@v4
-    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+    - uses: actions/checkout@v7.0.0
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.7
       with:
         bundle: tinycrate.flatpak
         manifest-path: linux/net.hhoney.tinycrate.yml

--- a/linux/net.hhoney.tinycrate.yml
+++ b/linux/net.hhoney.tinycrate.yml
@@ -1,31 +1,29 @@
 id: net.hhoney.tinycrate
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 base: org.godotengine.godot.BaseApp
-base-version: '3.6'
+base-version: '3.6-25.08'
 sdk: org.freedesktop.Sdk
 command: godot-runner
 finish-args:
-- --share=ipc
-- --socket=x11
-- --socket=pulseaudio
-- --device=all
+  - --share=ipc
+  - --socket=x11
+  - --socket=pulseaudio
+  - --device=all
 modules:
-- name: tinycrate
-  buildsystem: simple
-  sources:
-
-  - type: dir
-    path: ../
-
-  - type: file
-    url: https://github.com/HarmonyHoney/tiny_crate/releases/download/2025.1.16/Tiny-Crate.pck
-    sha256: ccf01fa100fe876e2a5d222f4cc7e60f57d2e09728f9948a188fa9ea4540d01b
-
-  build-commands:
-  - install -Dm644 Tiny-Crate.pck ${FLATPAK_DEST}/bin/godot-runner.pck
-  - install -Dm644 linux/${FLATPAK_ID}.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
-  - install -Dm644 linux/${FLATPAK_ID}.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
-  - install -Dm644 linux/${FLATPAK_ID}-symbolic.svg ${FLATPAK_DEST}/share/icons/hicolor/symbolic/apps/${FLATPAK_ID}-symbolic.svg
-  - install -Dm644 linux/${FLATPAK_ID}.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
-  - install -Dm644 linux/${FLATPAK_ID}.releases.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.releases.xml
+  - name: tinycrate
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 godot-runner.pck ${FLATPAK_DEST}/bin/godot-runner.pck
+      - install -Dm644 linux/${FLATPAK_ID}.desktop -t ${FLATPAK_DEST}/share/applications/
+      - install -Dm644 linux/${FLATPAK_ID}.svg -t ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/
+      - install -Dm644 linux/${FLATPAK_ID}-symbolic.svg -t ${FLATPAK_DEST}/share/icons/hicolor/symbolic/apps/
+      - install -Dm644 linux/${FLATPAK_ID}.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo/
+      - install -Dm644 linux/${FLATPAK_ID}.releases.xml -t ${FLATPAK_DEST}/share/metainfo/
+    sources:
+      - type: dir
+        path: ../
+      - type: file
+        url: https://github.com/HarmonyHoney/tiny_crate/releases/download/2026.03.12/tinycrate-ci-2026.03.12.pck
+        sha256: 4bd2b55a2258ca9ff8fd5d1bc6345da353ab235c9306209c55034ecb73a8008d
+        dest-filename: godot-runner.pck


### PR DESCRIPTION
Mirroring changes from https://github.com/flathub/net.hhoney.tinycrate/pull/14